### PR TITLE
My Solution

### DIFF
--- a/lib/setup_sink/app.rb
+++ b/lib/setup_sink/app.rb
@@ -1,4 +1,5 @@
 require "redis"
+require "json"
 
 module SetupSink
   class App
@@ -18,11 +19,120 @@ module SetupSink
     end
 
     def get(env)
-      [200, {}, ["OK"]]
+      if match = env["PATH_INFO"].match(/^\/metrics\/(?<project>.*)/)
+        metrics = return_metrics(match[:project])
+        if metrics
+          response = JSON.generate(metrics)
+          return [200, {"Content-Type"=>"application/json"}, [response]]
+        else
+          return [404, {"Content-Type"=>"application/json"}, [JSON.generate({ error: "No such project \"#{match[:project]}\" found" })]]
+        end
+      else
+        [200, {}, ["Path Info: #{env["PATH_INFO"]}"]]
+      end
     end
 
     def post(env)
-      [201, {}, ["Created"]]
+      path = env['PATH_INFO']
+      case path
+      when "/metrics"
+        if store_metrics(JSON.parse(env['rack.input'].read))
+          return [201, {}, [JSON.generate( { message: "Metrics stored correctly" })]]
+        else
+          return [404, {}, [JSON.generate( { error: "Metrics not stored correctly" })]]
+        end
+      when "/delete"
+        if delete_project(split_path[2])
+          return [201, {}, ["#{split_path[2]} deleted"]]
+        else
+          return [404, {}, ["No such project \"#{split_path[2]}\" found"]]
+        end
+      when "/_delete_all"
+        if delete_all
+          return [201, {}, ["database deleted"]]
+        else
+          return [409, {}, ["Database not deleted correctly"]]
+        end
+      when "/all"
+        projects = get_all
+        if projects.length > 0
+          return [201, {}, ["All Projects: #{projects}"]]
+        else
+          return [404, {}, ["No projects in database"]]
+        end
+      else
+        
+      end
+      [201, {}, ["Path Info: #{env["PATH_INFO"]}"]]
+    end
+
+    def store_metrics(req)
+      project = req["project"]
+      if !@redis.exists?(project)
+        hash = {
+          start_time: req["start_time"],
+          number_of_setups: 1,
+          successes: req["success"] == "true" ? 1 : 0,
+          success_rate: req["success"] == "true" ? 1 : 0,
+          average_duration: req["duration"]
+        }
+      else
+        hash = get_metrics(project)
+        number_of_setups = hash["number_of_setups"].to_i
+        successes = hash["successes"].to_i
+        success_rate = hash["success_rate"].to_f
+        average_duration = hash["average_duration"].to_f
+
+        hash["number_of_setups"] = number_of_setups + 1
+        if req["success"] == "true"
+          hash["successes"] = successes + 1
+        end
+        hash["success_rate"] = ((hash["successes"].to_f) / (number_of_setups + 1)).to_f
+        hash["average_duration"] = (average_duration + req["duration"].to_f) / 2
+      end
+      field_count = @redis.hset(project, hash)
+      field_count == hash.keys.length
+    end
+
+    def get_metrics(project)
+      if @redis.exists?(project)
+        @redis.hgetall(project)
+      end
+    end
+
+    def return_metrics(project)
+      if @redis.exists?(project)
+        project = @redis.hgetall(project)
+        return {
+          success_rate: (project["success_rate"].to_f*100.0).round(2),
+          average_duration: project["average_duration"].to_f.round(2),
+          number_of_setups: project["number_of_setups"].to_i
+        }
+      end
+    end
+
+    def delete_project(project)
+      if @redis.exists?(project)
+        @redis.del(project)
+        true
+      else
+        false
+      end
+    end
+
+    def get_all
+      @redis.scan_each.to_a
+    end
+
+    def delete_all
+      @redis.scan_each do |key|
+        @redis.del(key)
+      end
+      if @redis.scan_each.to_a.length == 0
+        true
+      else
+        false
+      end
     end
   end
 end

--- a/test/setup_sink_test.rb
+++ b/test/setup_sink_test.rb
@@ -3,7 +3,86 @@
 require "test_helper"
 
 class SetupSinkTest < Minitest::Test
+  include Rack::Test::Methods
   def test_that_it_has_a_version_number
     refute_nil ::SetupSink::VERSION
+  end
+
+  def teardown
+    delete_all
+  end
+
+  def redis_client
+    @redis ||= Redis.new(host: "localhost", port: 6379) 
+  end
+
+  def delete_all
+    redis_client.scan_each do |key|
+      redis_client.del(key)
+    end
+    if redis_client.scan_each.to_a.length == 0
+      true
+    else
+      false
+    end
+  end
+
+  def app
+    Rack::Builder.new do |builder|
+      builder.use Rack::Session::Pool
+      builder.run SetupSink::App.new(host: "localhost", port: 6379)
+    end.to_app
+  end
+
+  def test_gets_ok_response_from_server
+    get "/foo"
+
+    assert last_response.ok?
+  end
+
+  def test_post_returns_ok
+    data = {
+      "success":"false",
+      "duration":"1.8",
+      "start_time":"678348792",
+      "project":"test"
+    }
+    post "/metrics/test", JSON.generate(data)
+
+    assert_equal 201, last_response.status
+  end
+
+  def test_post_stores_data_in_redis_correctly
+    data = {
+      "success":"false",
+      "duration":"1.8",
+      "start_time":"678348792",
+      "project":"test"
+    }
+    json_data = JSON.generate(data)
+    post "/metrics", json_data
+
+    assert_equal 201, last_response.status
+    assert redis_client.exists?("test")
+  end
+
+  def test_post_incements_metrics
+    data = {
+      "success":"false",
+      "duration":"1.8",
+      "start_time":"678348792",
+      "project":"test"
+    }
+    post "/metrics", JSON.generate(data)
+
+    get "/metrics/test"
+
+    assert_equal 200, last_response.status
+
+    parsed_data = JSON.parse(last_response.body)
+
+    assert_equal 0, parsed_data["success_rate"]
+    assert_equal 1.8, parsed_data["average_duration"]
+    assert_equal 1, parsed_data["number_of_setups"]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,5 +3,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "bundler/setup"
 require "setup_sink"
+require "rack/test"
+require "json"
 
 require "minitest/autorun"


### PR DESCRIPTION
The `SetupSink` module contains the `App` class but can be extracted in the future for flexibility.  The `initialize` method takes the host and port for the `redis` object for the storage. The `call` method gets the request method and parses the request, in this case either "GET" or "POST" otherwise a 422 status is sent back.  The `get` method handles get requests. The path info is parsed  to determine the name of the project. The `return_metrics` takes the `req` in order to get the project name. If the project does not exists in the `redis` data structure, create a hash with the needed info from the exercise instructions: `start_time`, `number_of_setups`, `successes`, `success_rate`, and `average_duration`. If it does exist, iterate on the existing gotten by the `get_metrics` method. The `return_metrics` method returns a hash with the data needed from the instructions for a `get` request to then send it as a JSON payload. The `delete_project`, `get_all`, and `delete_all` methods are just helper functions for development. 

Co-authored-by: Andrew Nordman <cadwallion@github.com>